### PR TITLE
Fixed issue where connection is not added to the default scene in the absence of global scene

### DIFF
--- a/Assets/FishNet/Plugins/Alven/SessionManagement/Runtime/Components/SessionPlayerSpawner.cs
+++ b/Assets/FishNet/Plugins/Alven/SessionManagement/Runtime/Components/SessionPlayerSpawner.cs
@@ -96,6 +96,10 @@ namespace FishNet.Alven.SessionManagement
             // A player object can be created for a player if the player has previously connected and loaded the start scenes.
             if (_playerObjects.ContainsKey(player))
             {
+                if (_addToDefaultScene) {
+                    NetworkObject existingNob = _playerObjects[player].NetworkObject;
+                    _networkManager.SceneManager.AddOwnerToDefaultScene(existingNob);
+                }
                 return;
             }
 


### PR DESCRIPTION
Fixed issue where connection is not added to the default scene in the absence of global scene